### PR TITLE
avoid duplicated pipeline scan when push and pr trigger both true

### DIFF
--- a/src/handlers/handler.js
+++ b/src/handlers/handler.js
@@ -1,29 +1,29 @@
 const { shouldRunForRepository } = require('../services/config-services/should-run');
 const { getDispatchEvents } = require('../services/dispatch-event-services/get-dispatch-events');
 const { createDispatchEvent } = require('../services/dispatch-event-services/dispatch');
-const { getVeracodeScanConfig, 
+const { getVeracodeScanConfig,
   getEnabledRepositoriesFromOrg, getAppConfigFromRepo } = require('../services/config-services/get-veracode-config');
 const appConfig = require('../app-config');
 
 async function handleEvents(app, context) {
-  const { deleted, 
-    repository: { id: repoId, name: repoName, archived, full_name: repoFullName, owner: { login } }, 
-    installation: { id: installationId } 
+  const { deleted,
+    repository: { id: repoId, name: repoName, archived, full_name: repoFullName, owner: { login } },
+    installation: { id: installationId }
   } = context.payload;
 
   // 1. handle branch deletion - will not trigger the process
   // 2. handle repository archiving - will not trigger the process
   //    although we should not expect to see push event from an archived repository
   if (archived) return;
-  
-  
+
+
   // 3. handle enabled repositories - if file exists and the repository is not enabled, will not trigger the process
   const enabledRepositories = await getEnabledRepositoriesFromOrg(app, context);
   if (enabledRepositories !== null && !enabledRepositories.includes(repoName)) return;
 
   // 4. handle excluded repositories - if repository is excluded, will not trigger the process
   const excludedRepositories = [appConfig().defaultOrganisationRepository];
-  if(!shouldRunForRepository(repoName, excludedRepositories))
+  if (!shouldRunForRepository(repoName, excludedRepositories))
     return;
 
   // 5. get app config from default organisation repository
@@ -34,25 +34,37 @@ async function handleEvents(app, context) {
   const token = await api.apps.createInstallationAccessToken({
     installation_id: installationId,
     repository_ids: [repoId]
-  })
+  });
 
-  const branch = context.name === 'push' ? 
+  const branch = context.name === 'push' ?
     context.payload.ref.replace('refs/heads/', '') : context.payload.pull_request.head.ref;
   const sha = context.name === 'push' ? context.payload.after : context.payload.pull_request.head.sha;
 
   let dispatchEvents = [];
-  // 5.5 if the pull request is closed, dispatch an event to remove the sandbox
-  if ((context.name === 'pull_request' && context.payload.action === 'closed' && context.payload.pull_request?.merged) ||
-     (context.name === 'push' && deleted))
-    dispatchEvents.push({
-      event_type: 'veracode-remove-sandbox',
-      repository: appConfig().defaultOrganisationRepository,
-      event_trigger: 'veracode-remove-sandbox',
-    });
-  else dispatchEvents = await getDispatchEvents(app, context, branch, veracodeScanConfigs);
+  // 5.1 if the branch is deleted and if the veracode_sandbox_scan_workflow is ON, dispatch an event to remove the sandbox
+  // Otherwise, return
+  if (context.name === 'push' && deleted) {
+    if (veracodeAppConfig.veracode_sandbox_scan_workflow)
+      dispatchEvents.push({
+        event_type: 'veracode-remove-sandbox',
+        repository: appConfig().defaultOrganisationRepository,
+        event_trigger: 'veracode-remove-sandbox',
+      });
+    else return;
+  } else if (context.name === 'pull_request' && context.payload.action === 'closed' && context.payload.pull_request?.merged) {
+    if (veracodeAppConfig.veracode_sandbox_scan_workflow)
+      dispatchEvents.push({
+        event_type: 'veracode-remove-sandbox',
+        repository: appConfig().defaultOrganisationRepository,
+        event_trigger: 'veracode-remove-sandbox',
+      });
+    else return;
+  } else {
+    dispatchEvents = await getDispatchEvents(app, context, branch, veracodeScanConfigs, undefined, veracodeAppConfig);
+  }
 
-  if (branch === appConfig().prBranch) return
-  
+  if (branch === appConfig().prBranch) return;
+
   const dispatchEventData = {
     context,
     payload: {
@@ -61,14 +73,14 @@ async function handleEvents(app, context) {
       token: token.data.token,
       callback_url: `${appConfig().appUrl}/register`,
       // TODO: read veracode.yml to get profile name
-      profile_name: repoFullName, 
+      profile_name: repoFullName,
       repository: {
         owner: login,
         name: repoName,
         full_name: repoFullName,
       }
     }
-  }
+  };
 
   const requests = dispatchEvents.map(event => createDispatchEvent(event, dispatchEventData));
   await Promise.all(requests);
@@ -76,4 +88,4 @@ async function handleEvents(app, context) {
 
 module.exports = {
   handleEvents,
-}
+};

--- a/src/services/config-services/get-veracode-config.js
+++ b/src/services/config-services/get-veracode-config.js
@@ -11,7 +11,7 @@ async function getVeracodeScanConfig(app, context, veracodeAppConfig) {
   let veracodeConfigFromRepo = await getConfigFileFromRepo(
     app, octokit, owner, originalRepo, veracodeAppConfig.scan_config_file_location);
   // 2. if veracode.yml does not exist in original repository, get veracode.yml from default organization repository
-  if (veracodeConfigFromRepo === null) 
+  if (veracodeConfigFromRepo === null)
     veracodeConfigFromRepo = await getConfigFileFromRepo(
       app, octokit, owner, appConfig().defaultOrganisationRepository, veracodeAppConfig.scan_config_file_location);
 
@@ -55,8 +55,9 @@ async function getAppConfigFromRepo(app, context) {
   const defaultAppConfig = {
     scan_config_file_location: 'veracode.yml',
     process_scan_results_in_action: false,
+    veracode_sandbox_scan_workflow: false,
   };
-  const appConfigFile = await getConfigFileFromRepo(app, octokit, owner, 
+  const appConfigFile = await getConfigFileFromRepo(app, octokit, owner,
     appConfig().defaultOrganisationRepository, appConfig().appConfigFile);
   if (appConfigFile === null) return defaultAppConfig;
   try {
@@ -87,4 +88,4 @@ module.exports = {
   getVeracodeScanConfig,
   getEnabledRepositoriesFromOrg,
   getAppConfigFromRepo
-}
+};


### PR DESCRIPTION
When pull_request and push triggers are both true:
1. Push no pr: run a new pipeline-scan
2. Push in pr: run a new pipeline and sandbox scan
3. Create a new pr: display previous pipeline scan and run a sandbox scan